### PR TITLE
fix photo select button url

### DIFF
--- a/app/assets/javascripts/spina/admin/summernote-extensions.js.erb
+++ b/app/assets/javascripts/spina/admin/summernote-extensions.js.erb
@@ -182,7 +182,7 @@
                     click: function() {
                         context.invoke('saveRange');
                         editor_id = $(this).parents('.horizontal-form-content').children('textarea')[0].id;
-                        $.get("/admin/photos/wysihtml5_select/" + editor_id);
+                        $.get("<%= Spina::Engine.routes.url_helpers.wysihtml5_select_admin_photos_path('') %>/#{editor_id}")
                     }
                 });
 


### PR DESCRIPTION
This works fine when Spina is mounted at `/` but not if Spina is mounted to something else i.e. `/cms` or `/pages`